### PR TITLE
GitHub pages  + Open AI API = <3

### DIFF
--- a/.github/workflows/deploy_to_ghp.yaml
+++ b/.github/workflows/deploy_to_ghp.yaml
@@ -3,8 +3,7 @@ name: Build and Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master
-      - feature/github-pages-open-ai-connection
+      - main
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy_to_ghp.yaml
+++ b/.github/workflows/deploy_to_ghp.yaml
@@ -3,7 +3,7 @@ name: Build and Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master  # Set your default branch here
+      - master
       - feature/github-pages-open-ai-connection
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '14'  # Set your Node.js version here
+          node-version: '18'  # Set your Node.js version here
 
       - name: Install dependencies 📦
         run: npm install

--- a/.github/workflows/deploy_to_ghp.yaml
+++ b/.github/workflows/deploy_to_ghp.yaml
@@ -27,6 +27,7 @@ jobs:
         run: npm run build
         env:
           VITE_OPENAI_API_KEY: ${{ secrets.VITE_OPENAI_API_KEY }}
+          VITE_OPENAI_API_KEY_PASSWORD: ${{ secrets.VITE_OPENAI_API_KEY_PASSWORD }}
 
       - name: Deploy 📤
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy_to_ghp.yaml
+++ b/.github/workflows/deploy_to_ghp.yaml
@@ -1,0 +1,35 @@
+name: Build and Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master  # Set your default branch here
+      - feature/github-pages-open-ai-connection
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: github-pages
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'  # Set your Node.js version here
+
+      - name: Install dependencies 📦
+        run: npm install
+
+      - name: Build 🚀
+        run: npm run build
+        env:
+          VITE_OPENAI_API_KEY: ${{ secrets.VITE_OPENAI_API_KEY }}
+
+      - name: Deploy 📤
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build  # Set your build folder here

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
         "@reduxjs/toolkit": "^1.8.1",
+        "@types/crypto-js": "^4.2.1",
         "@types/react-redux": "^7.1.33",
         "crypto-js": "^4.2.0",
         "dotenv": "^16.3.1",
@@ -2991,6 +2992,11 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.1.tgz",
+      "integrity": "sha512-FSPGd9+OcSok3RsM0UZ/9fcvMOXJ1ENE/ZbLfOPlBWj7BgXtEAM8VYfTtT760GiLbQIMoVozwVuisjvsVwqYWw=="
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.11.0",
         "@reduxjs/toolkit": "^1.8.1",
         "@types/react-redux": "^7.1.33",
+        "crypto-js": "^4.2.0",
         "dotenv": "^16.3.1",
         "framer-motion": "^10.16.16",
         "react": "^18.2.0",
@@ -3863,6 +3864,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-box-model": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@reduxjs/toolkit": "^1.8.1",
+    "@types/crypto-js": "^4.2.1",
     "@types/react-redux": "^7.1.33",
     "crypto-js": "^4.2.0",
     "dotenv": "^16.3.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@emotion/styled": "^11.11.0",
     "@reduxjs/toolkit": "^1.8.1",
     "@types/react-redux": "^7.1.33",
+    "crypto-js": "^4.2.0",
     "dotenv": "^16.3.1",
     "framer-motion": "^10.16.16",
     "react": "^18.2.0",

--- a/src/store/gpt-api/gpt.api.ts
+++ b/src/store/gpt-api/gpt.api.ts
@@ -2,7 +2,10 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { IGptResponse } from '../../interfaces/responses/gpt-api';
 import { IGptRequest } from '../../interfaces/requests/gpt-api';
 
-const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+const apiKeyEncoded = import.meta.env.VITE_OPENAI_API_KEY;
+const apiKeyPassword = import.meta.env.VITE_OPENAI_API_KEY_PASSWORD;
+
+var CryptoJS = require("crypto-js");
 
 export const gptApi = createApi({
   reducerPath: 'api',
@@ -14,7 +17,7 @@ export const gptApi = createApi({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
+          Authorization: `Bearer` + CryptoJS.AES.decrypt(apiKeyEncoded, apiKeyPassword),
         },
         body: {
           model: 'gpt-3.5-turbo',

--- a/src/store/gpt-api/gpt.api.ts
+++ b/src/store/gpt-api/gpt.api.ts
@@ -5,7 +5,7 @@ import { IGptRequest } from '../../interfaces/requests/gpt-api';
 const apiKeyEncoded = import.meta.env.VITE_OPENAI_API_KEY;
 const apiKeyPassword = import.meta.env.VITE_OPENAI_API_KEY_PASSWORD;
 
-var CryptoJS = require("crypto-js");
+import CryptoJS from 'crypto-js'
 
 export const gptApi = createApi({
   reducerPath: 'api',
@@ -17,7 +17,7 @@ export const gptApi = createApi({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer` + CryptoJS.AES.decrypt(apiKeyEncoded, apiKeyPassword),
+          Authorization: `Bearer ` + CryptoJS.AES.decrypt(apiKeyEncoded, apiKeyPassword).toString(CryptoJS.enc.Utf8),
         },
         body: {
           model: 'gpt-3.5-turbo',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "strict": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
Sup.
I'm really sorry, but I don't have enough time to test your application well.
But to help you get feedback from other people I prepared this PR.

This thing - is a workaround to make GH pages work with Open AI API.

### Background

The problem with API key revoking is that GH scans content of GH Pages(or even all branches, not sure) for API keys(even injected from GH Actions) and shares this information with Open AI.
To avoid this, you can encrypt your API token and decrypt it during request sending.

**_It's not completely safe. Somebody still can steal you token_**, but it's fine for testing purposes I guess.

### How to set up

1. Create a new environment "github-pages" in Settings -> Environments
2. Add secrets "VITE_OPENAI_API_KEY" and "VITE_OPENAI_API_KEY_PASSWORD" in this environment: VITE_OPENAI_API_KEY - is an encoded API key, VITE_OPENAI_API_KEY_PASSWORD - passphrase for this encoded value; you can use this pen to encode your token -> https://codepen.io/gabrielizalo/pen/oLzaqx
3. Drop your gh-pages branch if it exists
4. Merge this PR
5. ???
6. PROFIT

Your website should be deployed each time you make commit to "main" branch.
I hope it will help you.

Proof of functionality: https://leuem.github.io/ai-exercises-generator/

ps Do not forget to squash commits
pss Not sure about quality of JS-part, so feel free to modify it